### PR TITLE
Add shebang and executable bit to script file

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os.path
 import sys
 


### PR DESCRIPTION
For the unitiated, the [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) allows a file to be directly executed, without specifying the interpreter, which, in this case, is set to Python 3.

Also set the executable bit, which is required.